### PR TITLE
Update PropTypes and Fix Bug iOS Code

### DIFF
--- a/Barcode.js
+++ b/Barcode.js
@@ -7,9 +7,9 @@
 
 
 import React, {
-    PropTypes,
     Component,
 } from 'react'
+
 import {
     View,
     requireNativeComponent,
@@ -17,6 +17,8 @@ import {
     AppState,
     Platform,
 } from 'react-native'
+
+import PropTypes from 'prop-types'
 
 const BarcodeManager = Platform.OS == 'ios' ? NativeModules.Barcode : NativeModules.CaptureModule
 

--- a/ios/RCTBarcode/RCTBarcode/RCTBarcode.h
+++ b/ios/RCTBarcode/RCTBarcode/RCTBarcode.h
@@ -10,7 +10,7 @@
 @property (nonatomic,strong)NSTimer *scanLineTimer;
 @property (nonatomic,strong)LineView *scanLine;
 @property (nonatomic,assign)CGRect scannerRect;
-@property (nonatomic, copy) RCTBubblingEventBlock onBarCodeRead;
+@property (nonatomic, copy) RCTDirectEventBlock onBarCodeRead;
 @property (nonatomic, assign) NSInteger scannerRectWidth;
 @property (nonatomic, assign) NSInteger scannerRectHeight;
 @property (nonatomic, assign) NSInteger scannerRectTop;

--- a/ios/RCTBarcode/RCTBarcode/RCTBarcodeManager.m
+++ b/ios/RCTBarcode/RCTBarcode/RCTBarcodeManager.m
@@ -24,7 +24,7 @@ RCT_EXPORT_VIEW_PROPERTY(scannerLineInterval, NSInteger)
 
 RCT_EXPORT_VIEW_PROPERTY(scannerRectCornerColor, NSString)
 
-RCT_EXPORT_VIEW_PROPERTY(onBarCodeRead, RCTBubblingEventBlock)
+RCT_EXPORT_VIEW_PROPERTY(onBarCodeRead, RCTDirectEventBlock)
 
 RCT_CUSTOM_VIEW_PROPERTY(barCodeTypes, NSArray, RCTBarcode) {
 //    NSLog(@"custom barCodeTypes -> %@", self.barCodeTypes);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,35 @@
+{
+  "name": "react-native-smart-barcode",
+  "version": "1.0.6",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+    },
+    "prop-types": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.6.2.tgz",
+      "integrity": "sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==",
+      "requires": {
+        "loose-envify": "^1.3.1",
+        "object-assign": "^4.1.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -24,5 +24,8 @@
   "homepage": "https://github.com/react-native-component/react-native-smart-barcode#readme",
   "peerDependencies": {
     "react-native": ">=0.40.0"
+  },
+  "dependencies": {
+    "prop-types": "^15.6.2"
   }
 }


### PR DESCRIPTION
PropTypes ->
In the new versions of React Native, PropTypes is no longer working when imported directly from React, as errors occur. For this reason the prop-types library was added and the import was changed.

Bug Fix iOS ->
When I compiled the code for iOS an error was reported, so I also changed this error based on another commit:

https://github.com/yz1311/react-native-smart-barcode/commit/82ceb0aa12adf96a121349ef9e606390a7a79153

https://github.com/yz1311/react-native-smart-barcode/commit/acb89ecab8a4b81006bcc05c4290e51947e7cd60